### PR TITLE
Improve indexing of references and parametrize ES index

### DIFF
--- a/fhirpath_helpers/elasticsearch/pytypes.py
+++ b/fhirpath_helpers/elasticsearch/pytypes.py
@@ -8,297 +8,309 @@
 Based on https://www.hl7.org/fhir/R4/datatypes.html, for other version
 need to make compatibility
 """
-from copy import deepcopy
-
-# FIXME: anlyzers, tokenizers and normalizers MUST NOT be hardcoded here
-# TODO: make a function to parametrize this mess
+from fhirpath.enums import FHIR_VERSION
 
 __author__ = "Md Nazrul Islam <email2nazrul@gmail.com>"
-date_pattern = "-?[0-9]{4}(-(0[1-9]|1[0-2])(-(0[0-9]|[1-2][0-9]|3[0-1]))?)?"
-datetime_pattern = "-?[0-9]{4}(-(0[1-9]|1[0-2])(-(0[0-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?"  # noqa
-Boolean = {"type": "boolean", "store": False}
-Float = {"type": "float", "store": False}
-Integer = {"type": "integer", "store": False}
-Long = {"type": "long", "store": False}
-Token = {
-    "type": "keyword",
-    "index": True,
-    "store": False,
-    "normalizer": "fhir_normalizer",
-    "fields": {
-        # index the raw text without normalization for exact matching
-        "raw": {"type": "keyword"}
-    },
-}
-ReferenceToken = {
-    "type": "text",
-    "index": True,
-    "store": False,
-    "analyzer": "fhir_reference_analyzer",
-}
-PathToken = {"type": "text", "index": True, "store": False, "analyzer": "path_analyzer"}
-Text = {
-    "type": "keyword",
-    "index": True,
-    "store": False,
-    "fields": {
-        # index the tokenized text with normalization for full text search
-        "tokenized": {"type": "text", "analyzer": "standard",},
-        # re-index the raw text without normalization for exact matching
-        "raw": {"type": "keyword"},
-    },
-}
-
-SearchableText = {"type": "text", "index": True, "analyzer": "standard", "store": False}
-
-Date = {
-    "type": "date",
-    "format": "date_time_no_millis||date_optional_time",
-    "store": False,
-}
-Time = {"type": "date", "format": "basic_t_time_no_millis", "store": False}
-
-Attachment = {
-    "properties": {"url": Token, "language": Token, "title": Text, "creation": Date}
-}
-
-Coding = {"properties": {"system": Token, "code": Token, "display": Token}}
-
-CodeableConcept = {
-    "properties": {
-        "text": Text,
-        "coding": {"type": "nested", "properties": Coding["properties"]},
-    }
-}
-
-Period = {"properties": {"start": Date, "end": Date}}
-Timing = {"properties": {"event": Date, "code": CodeableConcept}}
-
-Identifier = {
-    "properties": {
-        "use": Token,
-        "system": Token,
-        "value": Token,
-        "type": {"properties": {"text": Text}},
-    }
-}
-
-Reference = {"properties": {"reference": ReferenceToken, "identifier": Identifier}}
-
-Quantity = {
-    "properties": {"value": Float, "code": Token, "system": Token, "unit": Token}
-}
-
-Money = {"properties": {"value": Float, "currency": Token}}
-Money_STU3 = Quantity
-Range = {"properties": {"high": Quantity, "low": Quantity}}
-Ratio = {"properties": {"numerator": Quantity, "denominator": Quantity}}
-
-Age = Quantity
-Address = {
-    "properties": {
-        "city": Token,
-        "country": Token,
-        "postalCode": Token,
-        "state": Token,
-        "use": Token,
-    }
-}
-
-HumanName = {
-    "properties": {
-        "family": Token,
-        "text": Text,
-        "prefix": Token,
-        "given": Token,
-        "use": Token,
-        "period": Period,
-    },
-}
-
-Duration = Quantity
-
-ContactPoint = {
-    "properties": {
-        "period": Period,
-        "rank": Integer,
-        "system": Token,
-        "use": Token,
-        "value": Text,
-    }
-}
 
 
-ContactDetail = {
-    "properties": {"name": Token, "telecom": {**ContactPoint, "type": "nested"}}
-}
-
-Annotation = {
-    "properties": {
-        "authorReference": Reference,
-        "authorString": Text,
-        "text": Text,
-        "time": Date,
-    }
-}
-
-Dosage = {
-    "properties": {
-        "asNeededBoolean": Boolean,
-        "asNeededCodeableConcept": CodeableConcept,
-        "site": CodeableConcept,
-        "text": Text,
-        "timing": Timing,
-        "patientInstruction": Text,
-        "doseAndRate": {
-            "properties": {
-                "doseQuantity": Quantity,
-                "type": CodeableConcept,
-                "rateRatio": Ratio,
-                "rateRange": Range,
-                "rateQuantity": Quantity,
-            }
+def fhir_types_mapping(
+    fhir_release: str, reference_analyzer=None, token_normalizer=None,
+):
+    Boolean = {"type": "boolean", "store": False}
+    Float = {"type": "float", "store": False}
+    Integer = {"type": "integer", "store": False}
+    Token = {
+        "type": "keyword",
+        "index": True,
+        "store": False,
+        "fields": {
+            # index the raw text without normalization for exact matching
+            "raw": {"type": "keyword"}
         },
-        "maxDosePerPeriod": Ratio,
-        "maxDosePerAdministration": Quantity,
-        "maxDosePerLifetime": Quantity,
     }
-}
-Dosage_STU3 = {
-    "properties": {
-        "asNeededBoolean": Boolean,
-        "asNeededCodeableConcept": CodeableConcept,
-        "doseQuantity": Quantity,
-        "doseRange": Range,
-        "site": CodeableConcept,
-        "text": Text,
-        "timing": Timing,
-    }
-}
+    if token_normalizer:
+        Token.update({"normalizer": token_normalizer})
 
-RelatedArtifact = {
-    "properties": {
-        "type": Token,
+    ReferenceToken = {
+        "type": "text",
+        "index": True,
+        "store": False,
+    }
+    if reference_analyzer:
+        ReferenceToken.update(
+            {
+                "analyzer": reference_analyzer,
+                "fields": {
+                    # index the raw text without normalization for exact matching
+                    "raw": {"type": "keyword"}
+                },
+            }
+        )
+
+    Text = {
+        "type": "keyword",
+        "index": True,
+        "store": False,
+        "fields": {
+            # index the tokenized text with normalization for full text search
+            "tokenized": {"type": "text", "analyzer": "standard"},
+            # re-index the raw text without normalization for exact matching
+            "raw": {"type": "keyword"},
+        },
+    }
+
+    SearchableText = {
+        "type": "text",
+        "index": True,
+        "analyzer": "standard",
+        "store": False,
+    }
+
+    Date = {
+        "type": "date",
+        "format": "date_time_no_millis||date_optional_time",
+        "store": False,
+    }
+    Time = {"type": "date", "format": "basic_t_time_no_millis", "store": False}
+
+    Attachment = {
+        "properties": {"url": Token, "language": Token, "title": Text, "creation": Date}
+    }
+
+    Coding = {"properties": {"system": Token, "code": Token, "display": Token}}
+
+    CodeableConcept = {
+        "properties": {
+            "text": Text,
+            "coding": {"type": "nested", "properties": Coding["properties"]},
+        }
+    }
+
+    Period = {"properties": {"start": Date, "end": Date}}
+    Timing = {"properties": {"event": Date, "code": CodeableConcept}}
+
+    Identifier = {
+        "properties": {
+            "use": Token,
+            "system": Token,
+            "value": Token,
+            "type": {"properties": {"text": Text}},
+        }
+    }
+
+    Reference = {"properties": {"reference": ReferenceToken, "identifier": Identifier}}
+
+    Quantity = {
+        "properties": {"value": Float, "code": Token, "system": Token, "unit": Token}
+    }
+
+    Money = {"properties": {"value": Float, "currency": Token}}
+    Money_STU3 = Quantity
+    Range = {"properties": {"high": Quantity, "low": Quantity}}
+    Ratio = {"properties": {"numerator": Quantity, "denominator": Quantity}}
+
+    Age = Quantity
+    Address = {
+        "properties": {
+            "city": Token,
+            "country": Token,
+            "postalCode": Token,
+            "state": Token,
+            "use": Token,
+        }
+    }
+
+    HumanName = {
+        "properties": {
+            "family": Token,
+            "text": Text,
+            "prefix": Token,
+            "given": Token,
+            "use": Token,
+            "period": Period,
+        },
+    }
+
+    Duration = Quantity
+
+    ContactPoint = {
+        "properties": {
+            "period": Period,
+            "rank": Integer,
+            "system": Token,
+            "use": Token,
+            "value": Text,
+        }
+    }
+
+    ContactDetail = {
+        "properties": {"name": Token, "telecom": {**ContactPoint, "type": "nested"}}
+    }
+
+    Annotation = {
+        "properties": {
+            "authorReference": Reference,
+            "authorString": Text,
+            "text": Text,
+            "time": Date,
+        }
+    }
+
+    Dosage = {
+        "properties": {
+            "asNeededBoolean": Boolean,
+            "asNeededCodeableConcept": CodeableConcept,
+            "site": CodeableConcept,
+            "text": Text,
+            "timing": Timing,
+            "patientInstruction": Text,
+            "doseAndRate": {
+                "properties": {
+                    "doseQuantity": Quantity,
+                    "type": CodeableConcept,
+                    "rateRatio": Ratio,
+                    "rateRange": Range,
+                    "rateQuantity": Quantity,
+                }
+            },
+            "maxDosePerPeriod": Ratio,
+            "maxDosePerAdministration": Quantity,
+            "maxDosePerLifetime": Quantity,
+        }
+    }
+    Dosage_STU3 = {
+        "properties": {
+            "asNeededBoolean": Boolean,
+            "asNeededCodeableConcept": CodeableConcept,
+            "doseQuantity": Quantity,
+            "doseRange": Range,
+            "site": CodeableConcept,
+            "text": Text,
+            "timing": Timing,
+        }
+    }
+
+    RelatedArtifact = {
+        "properties": {
+            "type": Token,
+            "url": Token,
+            "resource": Reference,
+            "label": Text,
+            "display": Text,
+        }
+    }
+
+    RelatedArtifact_STU3 = {
+        "properties": {"type": Token, "url": Token, "resource": Reference}
+    }
+
+    Signature = {
+        "properties": {
+            "type": Coding,
+            "when": Date,
+            "who": Reference,
+            "targetFormat": Token,
+            "sigFormat": Token,
+            "onBehalfOf": Reference,
+        }
+    }
+
+    Signature_STU3 = {
+        "properties": {
+            "contentType": Token,
+            "when": Date,
+            "whoReference": Reference,
+            "whoUri": Token,
+        }
+    }
+    Population = {
+        "properties": {
+            "ageRange": Range,
+            "ageCodeableConcept": CodeableConcept,
+            "gender": CodeableConcept,
+            "race": CodeableConcept,
+            "physiologicalCondition": CodeableConcept,
+        }
+    }
+
+    Meta = {
+        "properties": {
+            "versionId": Token,
+            "lastUpdated": Date,
+            "profile": Token,
+            "tag": {**Coding, "type": "nested", "include_in_root": True},
+        }
+    }
+
+    Expression = {
+        "properties": {
+            "description": Token,
+            "name": Token,
+            "language": Token,
+            "expression": Token,
+            "reference": Token,
+        }
+    }
+
+    Narrative = {"properties": {"status": Token, "div": SearchableText}}
+
+    Count = Quantity
+    Distance = Quantity
+
+    return {
+        "boolean": Boolean,
+        "base64Binary": Token,
+        "integer": Integer,
+        "string": Text,
+        "decimal": Float,
+        "uri": Token,
         "url": Token,
-        "resource": Reference,
-        "label": Text,
-        "display": Text,
+        "canonical": Token,
+        "instant": Date,
+        "date": Date,
+        "dateTime": Date,
+        "time": Time,
+        "code": Token,
+        "oid": Token,
+        "id": Token,
+        "unsignedInt": Integer,
+        "positiveInt": Integer,
+        "uuid": Token,
+        "Attachment": Attachment,
+        "Coding": Coding,
+        "CodeableConcept": CodeableConcept,
+        "Quantity": Quantity,
+        "Distance": Distance,
+        "Count": Count,
+        "Money": {FHIR_VERSION.STU3.name: Money_STU3, FHIR_VERSION.R4.name: Money}[
+            fhir_release
+        ],
+        "Duration": Duration,
+        "Range": Range,
+        "Ratio": Ratio,
+        "Period": Period,
+        "Identifier": Identifier,
+        "HumanName": HumanName,
+        "Address": Address,
+        "ContactPoint": ContactPoint,
+        "Timing": Timing,
+        "Dosage": {FHIR_VERSION.STU3.name: Dosage_STU3, FHIR_VERSION.R4.name: Dosage}[
+            fhir_release
+        ],
+        "Meta": Meta,
+        "Annotation": Annotation,
+        "ContactDetail": ContactDetail,
+        "Age": Age,
+        "Reference": Reference,
+        "RelatedArtifact": {
+            FHIR_VERSION.STU3.name: RelatedArtifact_STU3,
+            FHIR_VERSION.R4.name: RelatedArtifact,
+        }[fhir_release],
+        "Signature": {
+            FHIR_VERSION.STU3.name: Signature_STU3,
+            FHIR_VERSION.R4.name: Signature,
+        }[fhir_release],
+        "Population": Population,
+        "Narrative": Narrative,
+        "Expression": Expression,
     }
-}
-
-RelatedArtifact_STU3 = {
-    "properties": {"type": Token, "url": Token, "resource": Reference}
-}
-
-
-Signature = {
-    "properties": {
-        "type": Coding,
-        "when": Date,
-        "who": Reference,
-        "targetFormat": Token,
-        "sigFormat": Token,
-        "onBehalfOf": Reference,
-    }
-}
-
-Signature_STU3 = {
-    "properties": {
-        "contentType": Token,
-        "when": Date,
-        "whoReference": Reference,
-        "whoUri": Token,
-    }
-}
-Population = {
-    "properties": {
-        "ageRange": Range,
-        "ageCodeableConcept": CodeableConcept,
-        "gender": CodeableConcept,
-        "race": CodeableConcept,
-        "physiologicalCondition": CodeableConcept,
-    }
-}
-
-# Common
-Id = Token
-Meta = {
-    "properties": {
-        "versionId": Token,
-        "lastUpdated": Date,
-        "profile": Token,
-        "tag": {**Coding, "type": "nested", "include_in_root": True},
-    }
-}
-
-Expression = {
-    "properties": {
-        "description": Token,
-        "name": Token,
-        "language": Token,
-        "expression": Token,
-        "reference": Token,
-    }
-}
-
-Narrative = {"properties": {"status": Token, "div": SearchableText}}
-
-Count = Quantity
-Distance = Quantity
-
-fhir_data_types_maps = {
-    "boolean": Boolean,
-    "base64Binary": Token,
-    "integer": Integer,
-    "string": Text,
-    "decimal": Float,
-    "uri": Token,
-    "url": Token,
-    "canonical": Token,
-    "instant": Date,
-    "date": Date,
-    "dateTime": Date,
-    "time": Time,
-    "code": Token,
-    "oid": Token,
-    "id": Token,
-    "unsignedInt": Integer,
-    "positiveInt": Integer,
-    "uuid": Token,
-    "Attachment": Attachment,
-    "Coding": Coding,
-    "CodeableConcept": CodeableConcept,
-    "Quantity": Quantity,
-    "Distance": Distance,
-    "Count": Count,
-    "Money": Money,
-    "Duration": Duration,
-    "Range": Range,
-    "Ratio": Ratio,
-    "Period": Period,
-    "Identifier": Identifier,
-    "HumanName": HumanName,
-    "Address": Address,
-    "ContactPoint": ContactPoint,
-    "Timing": Timing,
-    "Dosage": Dosage,
-    "Meta": Meta,
-    "Annotation": Annotation,
-    "ContactDetail": ContactDetail,
-    "Age": Age,
-    "Reference": Reference,
-    "RelatedArtifact": RelatedArtifact,
-    "Signature": Signature,
-    "Population": Population,
-    "Narrative": Narrative,
-    "Expression": Expression,
-}
-fhir_data_types_maps_STU3 = deepcopy(fhir_data_types_maps)
-fhir_data_types_maps_STU3.update(
-    {
-        "Dosage": Dosage_STU3,
-        "Money": Money_STU3,
-        "RelatedArtifact": RelatedArtifact_STU3,
-        "Signature": Signature_STU3,
-    }
-)

--- a/fhirpath_helpers/elasticsearch/pytypes.py
+++ b/fhirpath_helpers/elasticsearch/pytypes.py
@@ -20,6 +20,12 @@ Long = {"type": "long", "store": False}
 Token = {"type": "keyword", "index": True, "store": False}
 KeywordToken = {"type": "keyword", "index": True, "store": False}
 PathToken = {"type": "text", "index": True, "store": False, "analyzer": "path_analyzer"}
+FhirReferenceToken = {
+    "type": "text",
+    "index": True,
+    "store": False,
+    "analyzer": "fhir_reference_analyzer",
+}
 Text = {
     "type": "text",
     "index": True,
@@ -36,7 +42,7 @@ Date = {
 }
 Time = {"type": "date", "format": "basic_t_time_no_millis", "store": False}
 
-Reference = {"properties": {"reference": KeywordToken}}
+Reference = {"properties": {"reference": FhirReferenceToken}}
 
 Attachment = {
     "properties": {"url": Token, "language": Token, "title": Text, "creation": Date}
@@ -79,6 +85,7 @@ Address = {
         "postalCode": Token,
         "state": Token,
         "use": Token,
+        "text": Text,
     }
 }
 

--- a/fhirpath_helpers/elasticsearch/pytypes.py
+++ b/fhirpath_helpers/elasticsearch/pytypes.py
@@ -37,15 +37,7 @@ def fhir_types_mapping(
         "store": False,
     }
     if reference_analyzer:
-        ReferenceToken.update(
-            {
-                "analyzer": reference_analyzer,
-                "fields": {
-                    # index the raw text without normalization for exact matching
-                    "raw": {"type": "keyword"}
-                },
-            }
-        )
+        ReferenceToken.update({"analyzer": reference_analyzer})
 
     Text = {
         "type": "keyword",


### PR DESCRIPTION
two improvements:
- parametrize `generate_mappings()` in order to pass a custom analyzer for references and a custom normalizer for FHIR token fields. This is mandatory for some search features.
- index references in two ways:
    1. as text, using the custom analyzer to  index only the logical id in Resource.<ref_field>.reference
    2. as keyword, without any post-processing to provide exact-matching
